### PR TITLE
Subtitle issue fix

### DIFF
--- a/OpenEdXMobile/src/main/java/org/edx/mobile/player/AudioPlayerFragment.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/player/AudioPlayerFragment.java
@@ -55,6 +55,7 @@ import org.edx.mobile.util.AppConstants;
 import org.edx.mobile.util.DeviceSettingUtil;
 import org.edx.mobile.util.NetworkUtil;
 import org.edx.mobile.util.OrientationDetector;
+import org.edx.mobile.util.ParseSRT;
 import org.edx.mobile.util.UiUtil;
 import org.edx.mobile.util.Version;
 import org.edx.mobile.view.CourseBaseActivity;
@@ -70,7 +71,6 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Locale;
 import subtitleFile.Caption;
-import subtitleFile.FormatSRT;
 import subtitleFile.TimedTextObject;
 
 /**
@@ -1204,8 +1204,7 @@ public class AudioPlayerFragment extends BaseFragment implements IPlayerListener
                     for (String thisKey : localHashMap.keySet()) {
                         InputStream localInputStream = localHashMap.get(thisKey);
                         if (localInputStream != null) {
-                            TimedTextObject localTimedTextObject =
-                                    new FormatSRT().parseFile("temp.srt", localInputStream);
+                            TimedTextObject localTimedTextObject = new ParseSRT().parse("temp.srt", localInputStream);
                             srtList.put(thisKey, localTimedTextObject);
                             localInputStream.close();
                         }

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/player/PlayerFragment.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/player/PlayerFragment.java
@@ -55,6 +55,7 @@ import org.edx.mobile.util.BrowserUtil;
 import org.edx.mobile.util.DeviceSettingUtil;
 import org.edx.mobile.util.NetworkUtil;
 import org.edx.mobile.util.OrientationDetector;
+import org.edx.mobile.util.ParseSRT;
 import org.edx.mobile.util.UiUtil;
 import org.edx.mobile.util.Version;
 import org.edx.mobile.view.dialog.CCLanguageDialogFragment;
@@ -71,7 +72,6 @@ import java.util.LinkedHashMap;
 import java.util.Locale;
 
 import subtitleFile.Caption;
-import subtitleFile.FormatSRT;
 import subtitleFile.TimedTextObject;
 
 @SuppressLint("WrongViewCast")
@@ -1197,8 +1197,7 @@ public class PlayerFragment extends BaseFragment implements IPlayerListener, Ser
                         InputStream localInputStream = localHashMap.get(thisKey);
                         if (localInputStream != null)
                         {
-                            TimedTextObject localTimedTextObject =
-                                    new FormatSRT().parseFile("temp.srt", localInputStream);
+                            TimedTextObject localTimedTextObject = new ParseSRT().parse("temp.srt", localInputStream);
                             srtList.put(thisKey, localTimedTextObject);
                             localInputStream.close();
                         }

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/util/ParseSRT.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/util/ParseSRT.java
@@ -1,0 +1,161 @@
+package org.edx.mobile.util;
+
+import android.util.Log;
+
+import java.io.BufferedReader;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.io.SequenceInputStream;
+import java.io.StringWriter;
+import java.nio.charset.Charset;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Scanner;
+
+import subtitleFile.FatalParsingException;
+import subtitleFile.FormatSCC;
+import subtitleFile.FormatSRT;
+import subtitleFile.TimedTextObject;
+
+/**
+ * Created by Zohaib on 3/31/2018.
+ */
+
+public class ParseSRT {
+
+
+    public TimedTextObject parse(String fileName, InputStream localInputStream) throws IOException, FatalParsingException {
+
+        List<InputStream> inputStreamCopies = createInputStreamCopies(localInputStream);
+
+        if (inputStreamCopies == null)
+            return null;
+
+        if (!isProperSRTFormat(inputStreamCopies.get(0))) {
+            localInputStream = convertTxtToSRTFormat(inputStreamCopies.get(1));
+        } else {
+            localInputStream = inputStreamCopies.get(1);
+        }
+
+        return new FormatSRT().parseFile(fileName, localInputStream);
+    }
+
+    private InputStream convertTxtToSRTFormat(InputStream inputStream) throws IOException {
+
+        InputStreamReader in = new InputStreamReader(inputStream);
+        BufferedReader br = new BufferedReader(in);
+
+        StringBuilder converted = new StringBuilder();
+
+        String line = br.readLine();
+        int lineCounter = 0;
+        String lastTime = "00:00:00,000";
+
+        try {
+            while (line != null) {
+                if (!line.isEmpty()) {
+                    line = line.trim();
+                    //if its a blank line, ignore it, otherwise...
+                    lineCounter++;
+
+                    converted.append(lineCounter).append("\n");
+
+                    line = line.replace("[", "").replace("]", "");
+                    line = replaceLast(line, ":", ",");
+
+                    converted.append(lastTime).append(" --> ").append(line).append("\n");
+
+                    lastTime = line;
+                    line = "";
+
+                    while (line.isEmpty()) {
+                        line = br.readLine().trim();
+                    }
+
+                    while (!line.isEmpty()) {
+                        converted.append(line).append("\n");
+                        line = br.readLine().trim();
+                    }
+
+                    converted.append("\n");
+                }
+                line = br.readLine();
+            }
+
+        } catch (NullPointerException e) {
+            e.printStackTrace();
+        } finally {
+            //we close the reader
+            inputStream.close();
+        }
+
+
+        String convertedString = converted.toString();
+        return new ByteArrayInputStream(convertedString.getBytes(StandardCharsets.UTF_8));
+    }
+
+    private String replaceLast(String string, String substring, String replacement) {
+        int index = string.lastIndexOf(substring);
+        if (index == -1)
+            return string;
+        return string.substring(0, index) + replacement
+                + string.substring(index + substring.length());
+    }
+
+    private boolean isProperSRTFormat(InputStream localInputStream) {
+        try {
+            InputStreamReader in = new InputStreamReader(localInputStream, Charset.defaultCharset());
+            BufferedReader br = new BufferedReader(in);
+            String line = br.readLine();
+
+            if (line != null) {
+                line = line.replace("\uFEFF", "");
+                line = line.trim();
+
+                while (line.isEmpty()) {
+                    line = br.readLine().trim();
+                }
+                int num = Integer.parseInt(line);
+                return num >= 0;
+            }
+
+        } catch (IOException e) {
+            e.printStackTrace();
+        } catch (NumberFormatException e) {
+            e.printStackTrace();
+            Log.d(ParseSRT.class.getName(), "Subtitle is not in SRT format");
+        }
+
+        return false;
+    }
+
+    private List<InputStream> createInputStreamCopies(InputStream localInputStream) {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        byte[] buffer = new byte[1024];
+        int len;
+        try {
+            while ((len = localInputStream.read(buffer)) > -1) {
+                baos.write(buffer, 0, len);
+            }
+            baos.flush();
+        } catch (IOException e) {
+            e.printStackTrace();
+            return null;
+        }
+
+        ArrayList<InputStream> inputStreams = new ArrayList<>();
+
+        inputStreams.add(new ByteArrayInputStream(baos.toByteArray()));
+        inputStreams.add(new ByteArrayInputStream(baos.toByteArray()));
+
+        return inputStreams;
+    }
+
+
+}

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/util/ParseSRT.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/util/ParseSRT.java
@@ -55,35 +55,36 @@ public class ParseSRT {
 
         String line = br.readLine();
         int lineCounter = 0;
-        String lastTime = "00:00:00,000";
 
+        TimedTranscriptsObject tto = null;
         try {
             while (line != null) {
                 if (!line.isEmpty()) {
-                    line = line.trim();
-                    //if its a blank line, ignore it, otherwise...
+
                     lineCounter++;
 
-                    converted.append(lineCounter).append("\n");
-
+                    line = line.trim();
                     line = line.replace("[", "").replace("]", "");
                     line = replaceLast(line, ":", ",");
 
-                    converted.append(lastTime).append(" --> ").append(line).append("\n");
+                    if (tto != null) {
+                        tto.endTime = line;
+                        converted.append(tto.toString());
+                    }
 
-                    lastTime = line;
+                    tto = new TimedTranscriptsObject();
+                    tto.tag = lineCounter;
+                    tto.startTime = line;
+
                     line = "";
-
                     while (line.isEmpty()) {
                         line = br.readLine().trim();
                     }
 
                     while (!line.isEmpty()) {
-                        converted.append(line).append("\n");
+                        tto.addText(line);
                         line = br.readLine().trim();
                     }
-
-                    converted.append("\n");
                 }
                 line = br.readLine();
             }
@@ -95,6 +96,10 @@ public class ParseSRT {
             inputStream.close();
         }
 
+        if (tto != null) {
+            tto.endTime = "59:59:59,999";
+            converted.append(tto.toString());
+        }
 
         String convertedString = converted.toString();
         return new ByteArrayInputStream(convertedString.getBytes(StandardCharsets.UTF_8));
@@ -155,6 +160,29 @@ public class ParseSRT {
         inputStreams.add(new ByteArrayInputStream(baos.toByteArray()));
 
         return inputStreams;
+    }
+
+
+    private class TimedTranscriptsObject {
+        int tag;
+        String startTime;
+        String endTime;
+        String text;
+
+        TimedTranscriptsObject() {
+            text = "";
+        }
+
+        @Override
+        public String toString() {
+            return tag + "\n" +
+                    startTime + " --> " + endTime + "\n" +
+                    text + "\n";
+        }
+
+        void addText(String line) {
+            text = text.concat(line).concat("\n");
+        }
     }
 
 

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/util/TranscriptDownloader.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/util/TranscriptDownloader.java
@@ -27,7 +27,7 @@ public abstract class TranscriptDownloader implements Runnable {
     @Override
     public void run() {
         try {
-            final Response response = okHttpClientProvider.getWithOfflineCache()
+            final Response response = okHttpClientProvider.getNonOAuthBased()
                     .newCall(new Request.Builder()
                             .url(srtUrl)
                             .get()

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/LoginActivity.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/LoginActivity.java
@@ -325,7 +325,8 @@ public class LoginActivity
                         }
                     }, getString(android.R.string.cancel), null);
         } else {
-            showAlertDialog(getString(R.string.login_error), ErrorUtils.getErrorMessage(ex, LoginActivity.this));
+            showAlertDialog(getString(R.string.login_error),  getString(R.string.login_failed));
+//            showAlertDialog(getString(R.string.login_error), ErrorUtils.getErrorMessage(ex, LoginActivity.this));
             logger.error(ex);
         }
     }

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/adapters/TranscriptAdapter.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/adapters/TranscriptAdapter.java
@@ -2,8 +2,10 @@ package org.edx.mobile.view.adapters;
 
 import android.content.Context;
 import android.graphics.Typeface;
+import android.os.Build;
 import android.support.annotation.ColorInt;
 import android.support.v4.content.ContextCompat;
+import android.text.Html;
 import android.view.View;
 import android.widget.AdapterView;
 import android.widget.TextView;
@@ -32,6 +34,11 @@ public class TranscriptAdapter extends BaseListAdapter<Caption> {
         String captionText = model.content;
         if (captionText.endsWith("<br />")) {
             captionText = captionText.substring(0, captionText.length() - 6);
+        }
+        if (Build.VERSION.SDK_INT >= 24) {
+            captionText = Html.fromHtml(captionText, Html.FROM_HTML_MODE_LEGACY).toString();
+        } else {
+            captionText = Html.fromHtml(captionText).toString();
         }
         viewHolder.transcriptTv.setText(captionText);
         final int position = getPosition(model);


### PR DESCRIPTION
### Description
- Changed `OkHttpClient` from **oauth-based** to **no-auth** to support external url subtitles.
- Added a custom parser to parse non-compliant subtitles format text before transforming to **TimedTextObject**.

### Testing
- [ ] i18n
- [ ] RTL
- [ ] safecommit shows 0 violations
- [ ] Unit, integration, acceptance tests as appropriate
- [ ] Analytics
- [ ] Performance
- [ ] Database migrations are backwards-compatible
